### PR TITLE
Fixed padding and rounded note borders

### DIFF
--- a/index.html
+++ b/index.html
@@ -254,10 +254,10 @@
 
   <div class="container my-3 pt-3">
     <h1><b>Welcome To Noter JS</b></h1>
-    <div class="" style="background-color: none !important;">
+    <div class="mt-5 mb-4" style="background-color: none !important;">
       <div class="card-body p-0 bg-none">
         <!-- <h5 class="card-title">Add a note</h5> -->
-        <div class="form-group">
+        <div class="mb-4 form-group">
           <textarea class="form-control" id="addTxt" rows="3" placeholder="Enter a Note"></textarea>
         </div>
         <button class="ml-lg-0 btn btn-success my-2 my-sm-0 search_button tx--white" id="addBtn" ripple="ripple">Add
@@ -267,7 +267,7 @@
     <br>
     <h1><b>Checkout Your Notes</b></h1>
 
-    <div class="container p-0">
+    <div class="container p-0 mt-5">
       <div id="notes" class="row"></div>
     </div>
   </div>

--- a/js/app.js
+++ b/js/app.js
@@ -28,7 +28,7 @@ function showNotes(previewValue) {
     notesObj.forEach(function(element, index) {
       html += `
               <div class="col-md-4 col-sm-6 col-12  pb-4">
-                      <div class="bg-white p-3 pb-0" >
+                      <div class="bg-white rounded-lg p-3 pb-0" >
                           <h5 class="card-title">Note ${index + 1}</h5>
                           <p class="card-text"> ${element}</p>
                           <button id="${index}"onclick="editNote(this.id)" class="btn btn-warning mb-3">Edit Note</button>

--- a/js/app.js
+++ b/js/app.js
@@ -61,7 +61,7 @@ function showNotes() {
     notesObj.forEach(function(note, index){
          html += `
                 <div class="col-md-4 col-sm-6 col-12  pb-4">
-                        <div class="bg-white p-3 pb-0" >
+                        <div class="bg-white rounded p-3 pb-0" >
                             <h5 class="card-title">${note.title ? note.title : `Note ${index+1}` }</h5>
                             <p class="card-text"> ${note.content}</p>
                             <button id="${index}"onclick="editNote(this.id)" class="btn btn-warning mb-3">Edit Note</button>


### PR DESCRIPTION
Added padding between headings and add note and notes display area. Also rounded the note borders as they were too pointy

Closes #43 

![uichanges](https://user-images.githubusercontent.com/29351098/193434865-002605c1-01b7-4285-987a-7b91fa8fad68.png)
